### PR TITLE
Light Styling

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <head>
     <link rel="shortcut icon" href="https://chrzanowski.me/favicon.ico"/>
+    <link href="styles.css" rel="stylesheet">
+    <link rel="font" href="https://fonts.googleapis.com/css?family=Lobster|Montserrat">
+    <script src="https://unpkg.com/mithril/mithril.js"></script>
     <title>recipes.chrzanowski</title>
     <meta name="description" content="the recipe website">
-    <script src="https://unpkg.com/mithril/mithril.js"></script>
 </head>
 
-<body>
+<body class="container">
+    <p>test</p>
     <script src="ui.js"></script>
 </body>
 

--- a/html/styles.css
+++ b/html/styles.css
@@ -1,0 +1,24 @@
+/*
+ * Brian Chrzanowski
+ * 2021-09-09 13:28:26
+ *
+ * Recipe Webiste CSS
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap');
+
+:root {
+    --color-1: #50ffb1;
+    --color-2: #4fb286;
+    --color-3: #3c896d;
+    --color-4: #546d64;
+    --color-5: #4d685a;
+
+    --color-bg: #dadada;
+}
+
+.container {
+    background-color: var(--color-bg);
+    font-family: 'Noto', sans-serif;
+}
+


### PR DESCRIPTION
Basically ensured that we could style the UI given a style sheet

## Notes

This seems to have uncovered a small bug (nuance?) in `libmagic`. Basically, it doesn't recognize the CSS file as anything other than `text/plain`, so using the default `send_file` function won't set the MIME type correctly, preventing the browser from using it to draw styles.